### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "config": "^1.28.1",
     "express": "^4.16.2",
     "faker": "^4.1.0",
-    "pug": "^2.0.0-rc.4"
+    "pug": "latest"
   },
   "devDependencies": {
     "del": "^3.0.0",


### PR DESCRIPTION
Pug ^2.0.0-rc.4 contains deprecated dependencies that are causing the build to fail. The latest version works.